### PR TITLE
fix(vms): 当 devtmpfs 不可用时回退到 rbind /dev

### DIFF
--- a/pkg/vms/sys/mount.go
+++ b/pkg/vms/sys/mount.go
@@ -3,6 +3,7 @@ package sys
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"syscall"
@@ -38,8 +39,24 @@ func Mount(ctx context.Context, m MountOptions) (undo Undo, err error) {
 	var dirUndo Undo
 	if dirUndo, err = Mkdir(ctx, m.Target, 0777); err == nil {
 		bq.Put(dirUndo)
-		if err = syscall.Mount(m.Source, m.Target, m.Fstype, m.Flags, m.Data); err == nil {
+		err = syscall.Mount(m.Source, m.Target, m.Fstype, m.Flags, m.Data)
+		if err == nil {
 			bq.Put(mkUnmount(ctx, m.Target, "unmount"))
+		} else if m.Fstype == "devtmpfs" && err == syscall.ENODEV {
+			// Some minimal/custom kernels are built without CONFIG_DEVTMPFS.
+			// In that case reuse the container's existing /dev recursively,
+			// including child mounts such as /dev/pts and /dev/shm.
+			devtmpfsErr := err
+			err = syscall.Mount("/dev", m.Target, "", uintptr(syscall.MS_BIND|syscall.MS_REC), "")
+			if err == nil {
+				slog.WarnContext(ctx, "devtmpfs unavailable, fallback to rbind /dev",
+					slog.String("target", m.Target),
+					slog.String("err", devtmpfsErr.Error()))
+				bq.Put(mkUnmount(ctx, m.Target, "unmount"))
+			} else {
+				err = fmt.Errorf("mount devtmpfs failed: %v; fallback rbind /dev failed: %w",
+					devtmpfsErr, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
部分精简或定制 Linux 内核未启用 CONFIG_DEVTMPFS，此时为 chroot 环境挂载 devtmpfs 会返回 ENODEV，从而导致迅雷无法启动。

增加 devtmpfs 挂载失败时的回退逻辑：
1. 内核支持 devtmpfs 时继续保持原有行为;
2. 当返回 ENODEV 时递归绑定挂载容器现有的 /dev；
3. 保留 /dev/pts、/dev/shm 等子挂载、保持原有 /xunlei chroot 运行环境不变；

这样可以让迅雷在未启用 CONFIG_DEVTMPFS 的内核上正常运行。

fix #240, #238, #245